### PR TITLE
CGI unescape URI encoded file paths

### DIFF
--- a/lib/obsidian_bear/obsidian.rb
+++ b/lib/obsidian_bear/obsidian.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "cgi"
 require "fileutils"
 
 module ObsidianBear
@@ -50,7 +51,7 @@ module ObsidianBear
             f.puts line.gsub(Bear::ATTACHMENT_FORMAT) { |_|
                 match = Regexp.last_match
                 updated_link = File.join(ATTACHMENTS_FOLDER, match[:path])
-                "![[#{updated_link}]]"
+                "![[#{CGI.unescape(updated_link)}]]"
             }
           end
         end

--- a/lib/obsidian_bear/version.rb
+++ b/lib/obsidian_bear/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ObsidianBear
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
This was causing issues with note attachments, see: #1

Closes #1