### PR TITLE
Fix parsing logic when line starts with multi word tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 source "https://rubygems.org"
+ruby '>= 2.7'
 
 gem "rake", "~> 13.0"
 gem "minitest", "~> 5.0"

--- a/test/data/bear/multiple_tags_same_line.md
+++ b/test/data/bear/multiple_tags_same_line.md
@@ -1,3 +1,4 @@
 # Multiple tags same line
 
-#learning and #programming/ruby and #programming bear#
+#multi word# and #programming/ruby and #programming bear#
+#simple and #programming/rust and #testing

--- a/test/obsidian_bear/bear_test.rb
+++ b/test/obsidian_bear/bear_test.rb
@@ -39,7 +39,7 @@ module ObsidianBear
 
       assert_equal(
         {
-          "test/data/bear/multiple_tags_same_line.md" => ["learning", "programming/ruby", "programming_bear"],
+          "test/data/bear/multiple_tags_same_line.md" => ["multi_word", "programming/ruby", "programming_bear", "simple", "programming/rust", "testing"],
         },
         summary
       )


### PR DESCRIPTION
The previous code was generating incorrect tags when the first tag in the line was a multi word tag.

For example:

would become

`['learning', 'ruby']` instead of `['learning_whatever', 'ruby']`

Closes #7 